### PR TITLE
refactor: 전체 DAO 불필요한 예외(throws Exception) 제거

### DIFF
--- a/web-guide/src/main/java/egovframework/hyb/add/acl/service/impl/AcceleratorAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/acl/service/impl/AcceleratorAndroidAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012.06.18    서형주                  최초생성
+ * @ 2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author Device API 실행환경팀
  * @since 2012. 07. 23
@@ -47,9 +48,8 @@ public class AcceleratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 가속도 정보를 등록한다.
      * @param vo - 등록할 정보가 담긴 AcceleratorAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertAcceleratorInfo(AcceleratorAndroidAPIVO vo) throws Exception {
+    public int insertAcceleratorInfo(AcceleratorAndroidAPIVO vo) {
         return (Integer)insert("acceleratorAndroidAPIDAO.insertAcceleratorInfo", vo);
     }
 
@@ -57,9 +57,8 @@ public class AcceleratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 가속도 정보를 수정한다.
      * @param vo - 수정할 정보가 담긴 AcceleratorAPIVO
      * @return void형
-     * @exception Exception
      */
-    public void updateAcceleratorInfo(AcceleratorAndroidAPIVO vo) throws Exception {
+    public void updateAcceleratorInfo(AcceleratorAndroidAPIVO vo) {
         update("acceleratorAndroidAPIDAO.updateAcceleratorInfo", vo);
     }
 
@@ -67,9 +66,8 @@ public class AcceleratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 가속도 정보를 삭제한다.
      * @param vo - 삭제할 정보가 담긴 AcceleratorAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int deleteAcceleratorInfo(AcceleratorAndroidAPIVO vo) throws Exception {
+    public int deleteAcceleratorInfo(AcceleratorAndroidAPIVO vo) {
         return (Integer)delete("acceleratorAndroidAPIDAO.deleteAcceleratorInfo", vo);
     }
 
@@ -77,9 +75,8 @@ public class AcceleratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 가속도 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 AcceleratorAPIVO
      * @return 조회한 가속도 정보
-     * @exception Exception
      */
-    public AcceleratorAndroidAPIVO selectAcceleratorInfo(AcceleratorAndroidAPIVO vo) throws Exception {
+    public AcceleratorAndroidAPIVO selectAcceleratorInfo(AcceleratorAndroidAPIVO vo) {
         return (AcceleratorAndroidAPIVO) selectOne("acceleratorAndroidAPIDAO.selectAcceleratorInfo", vo);
     }
 
@@ -87,9 +84,8 @@ public class AcceleratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 가속도 정보 목록을 조회한다.
      * @param vo - 조회할 정보가 담긴 AcceleratorAPIDefaultVO
      * @return 가속도 정보 목록
-     * @exception Exception
      */
-    public List<?> selectAcceleratorInfoList(AcceleratorAndroidAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectAcceleratorInfoList(AcceleratorAndroidAPIDefaultVO searchVO) {
         return selectList("acceleratorAndroidAPIDAO.selectAcceleratorInfoList", searchVO);
     }
 
@@ -97,7 +93,6 @@ public class AcceleratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 가속도 정보 총 갯수를 조회한다.
      * @param  vo - 조회할 정보가 담긴 AcceleratorAPIDefaultVO
      * @return 가속도 정보 총 갯수
-     * @exception
      */
     public int selectAcceleratorInfoListTotCnt(AcceleratorAndroidAPIDefaultVO searchVO) {
         return (Integer) selectOne("acceleratorAndroidAPIDAO.selectAcceleratorInfoListTotCnt", searchVO);

--- a/web-guide/src/main/java/egovframework/hyb/add/cmr/service/impl/CameraAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/cmr/service/impl/CameraAndroidAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일            수정자        수정내용
  * @ ---------        ---------    -------------------------------
  * @ 2012. 7. 23.        이율경        최초생성
+ * @ 2026. 6. 26.        이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 개발환경 팀
  * @since 2012. 7. 23.
@@ -46,9 +47,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지를 등록한다.
      * @param vo - 등록할 정보가 담긴 CameraAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertCameraPhotoAlbum(CameraAndroidAPIFileVO vo) throws Exception {
+    public int insertCameraPhotoAlbum(CameraAndroidAPIFileVO vo) {
         return (Integer)insert("cameraAndroidAPIDAO.insertCameraPhotoAlbum", vo);
     }
     
@@ -56,9 +56,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 파일을 등록한다.
      * @param vo - 등록할 파일 정보가 담긴 CameraAndroidAPIFileVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertCameraPhotoAlbumFile(CameraAndroidAPIFileVO vo) throws Exception {
+    public int insertCameraPhotoAlbumFile(CameraAndroidAPIFileVO vo) {
         return (Integer)insert("cameraAndroidAPIDAO.insertCameraPhotoAlbumFile", vo);
     }
     
@@ -66,9 +65,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 파일을 수정한다.
      * @param vo - 등록할 정보가 담긴 CameraAndroidAPIFileVO
      * @return 수정 결과
-     * @exception Exception
      */
-    public int updateCameraPhotoAlbumInfoFile(CameraAndroidAPIFileVO vo) throws Exception {
+    public int updateCameraPhotoAlbumInfoFile(CameraAndroidAPIFileVO vo) {
         return (Integer)update("cameraAndroidAPIDAO.updateCameraPhotoAlbumFile", vo);
     }
 
@@ -76,9 +74,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지를 삭제한다.
      * @param vo - 삭제할 파일 정보가 담긴 CameraAPIVO
      * @return 삭제 결과
-     * @exception Exception
      */
-    public int deleteCameraPhotoAlbumInfo(CameraAndroidAPIVO vo) throws Exception {
+    public int deleteCameraPhotoAlbumInfo(CameraAndroidAPIVO vo) {
         return (Integer)delete("cameraAndroidAPIDAO.deleteCameraPhotoAlbumInfo", vo);
     }
     
@@ -86,9 +83,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 파일을  삭제한다.
      * @param vo - 삭제할 파일 정보가 담긴 CameraAndroidAPIFileVO
      * @return 삭제 결과 
-     * @exception Exception
      */
-    public int deleteCameraPhotoAlbumInfoFile(CameraAndroidAPIVO vo) throws Exception {
+    public int deleteCameraPhotoAlbumInfoFile(CameraAndroidAPIVO vo) {
         return (Integer)delete("cameraAndroidAPIDAO.deleteCameraPhotoAlbumInfoFile", vo);
     }
 
@@ -96,9 +92,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 CameraAPIVO
      * @return 조회한 네트워크 정보
-     * @exception Exception
      */
-    public CameraAndroidAPIVO selectCameraPhotoAlbumInfo(CameraAndroidAPIVO vo) throws Exception {
+    public CameraAndroidAPIVO selectCameraPhotoAlbumInfo(CameraAndroidAPIVO vo) {
         return (CameraAndroidAPIVO) selectOne("cameraAndroidAPIDAO.selectCameraPhotoAlbumInfo", vo);
     }
 
@@ -106,9 +101,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 정보 목록을 조회한다.
      * @param vo - 조회할 정보가 담긴 CameraAPIDefaultVO
      * @return 이미지 정보 목록
-     * @exception Exception
      */
-    public List<?> selectCameraPhotoAlbumInfoList(CameraAndroidAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectCameraPhotoAlbumInfoList(CameraAndroidAPIDefaultVO searchVO) {
         return selectList("cameraAndroidAPIDAO.selectCameraPhotoAlbumInfoList", searchVO);
     }
     
@@ -116,9 +110,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 파일 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 CameraAndroidAPIFileVO
      * @return 이미지 파일 정보
-     * @exception Exception
      */
-    public CameraAndroidAPIFileVO selectImageFileInfo(CameraAndroidAPIFileVO vo) throws Exception {
+    public CameraAndroidAPIFileVO selectImageFileInfo(CameraAndroidAPIFileVO vo) {
         return (CameraAndroidAPIFileVO) selectOne("cameraAndroidAPIDAO.selectImageFileInfo", vo);
     }
     
@@ -126,9 +119,8 @@ public class CameraAndroidAPIDAO extends EgovComAbstractDAO {
      * 이미지 제목 중복을 조회한다.
      * @param vo - 조회할 정보가 담긴 CameraAndroidAPIFileVO
      * @return 파일연번 정보
-     * @exception Exception
      */
-    public CameraAndroidAPIFileVO selectPhotoAlbumPhotoSj(CameraAndroidAPIFileVO vo) throws Exception {
+    public CameraAndroidAPIFileVO selectPhotoAlbumPhotoSj(CameraAndroidAPIFileVO vo) {
         return (CameraAndroidAPIFileVO) selectOne("cameraAndroidAPIDAO.selectCameraPhotoAlbumPhotoSj", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/add/cps/service/impl/CompassAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/cps/service/impl/CompassAndroidAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012.06.18    서형주                  최초생성
+ * @ 2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author Device API 실행환경팀
  * @since 2012. 07. 30
@@ -47,9 +48,8 @@ public class CompassAndroidAPIDAO extends EgovComAbstractDAO {
      * 방향 정보를 등록한다.
      * @param vo - 등록할 정보가 담긴 CompassAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertCompassInfo(CompassAndroidAPIVO vo) throws Exception {
+    public int insertCompassInfo(CompassAndroidAPIVO vo) {
         return (Integer)insert("compassAndroidAPIDAO.insertCompassInfo", vo);
     }
 
@@ -57,9 +57,8 @@ public class CompassAndroidAPIDAO extends EgovComAbstractDAO {
      * 방향 정보를 수정한다.
      * @param vo - 수정할 정보가 담긴 CompassAPIVO
      * @return void형
-     * @exception Exception
      */
-    public void updateCompassInfo(CompassAndroidAPIVO vo) throws Exception {
+    public void updateCompassInfo(CompassAndroidAPIVO vo) {
         update("compassAndroidAPIDAO.updateCompassInfo", vo);
     }
 
@@ -67,9 +66,8 @@ public class CompassAndroidAPIDAO extends EgovComAbstractDAO {
      * 방향 정보를 삭제한다.
      * @param vo - 삭제할 정보가 담긴 CompassAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int deleteCompassInfo(CompassAndroidAPIVO vo) throws Exception {
+    public int deleteCompassInfo(CompassAndroidAPIVO vo) {
         return (Integer)delete("compassAndroidAPIDAO.deleteCompassInfo", vo);
     }
 
@@ -77,9 +75,8 @@ public class CompassAndroidAPIDAO extends EgovComAbstractDAO {
      * 방향 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 CompassAPIVO
      * @return 조회한 방향 정보
-     * @exception Exception
      */
-    public CompassAndroidAPIVO selectCompassInfo(CompassAndroidAPIVO vo) throws Exception {
+    public CompassAndroidAPIVO selectCompassInfo(CompassAndroidAPIVO vo) {
         return (CompassAndroidAPIVO) selectOne("compassAndroidAPIDAO.selectCompassInfo", vo);
     }
 
@@ -87,9 +84,8 @@ public class CompassAndroidAPIDAO extends EgovComAbstractDAO {
      * 방향 정보 목록을 조회한다.
      * @param vo - 조회할 정보가 담긴 CompassAPIDefaultVO
      * @return 방향 정보 목록
-     * @exception Exception
      */
-    public List<?> selectCompassInfoList(CompassAndroidAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectCompassInfoList(CompassAndroidAPIDefaultVO searchVO) {
         return selectList("compassAndroidAPIDAO.selectCompassInfoList", searchVO);
     }
 
@@ -97,7 +93,6 @@ public class CompassAndroidAPIDAO extends EgovComAbstractDAO {
      * 방향 정보 총 갯수를 조회한다.
      * @param  vo - 조회할 정보가 담긴 CompassAPIDefaultVO
      * @return 방향 정보 총 갯수
-     * @exception
      */
     public int selectCompassInfoListTotCnt(CompassAndroidAPIDefaultVO searchVO) {
         return (Integer) selectOne("compassAndroidAPIDAO.selectCompassInfoListTotCnt", searchVO);

--- a/web-guide/src/main/java/egovframework/hyb/add/ctt/service/impl/ContactsAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/ctt/service/impl/ContactsAndroidAPIDAO.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012. 8. 13.  나신일                   최초생성
+ * @ 2026. 6. 26.  이백행                   [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 8. 13
@@ -32,9 +33,8 @@ public class ContactsAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param vo
      *            - 연락처 정보가 담긴 ContactsAndroidAPIVO
-     * @exception Exception
      */
-    public void insertContactsInfo(ContactsAndroidAPIVO vo) throws Exception {
+    public void insertContactsInfo(ContactsAndroidAPIVO vo) {
         insert("contactsAndroidAPIDAO.insertContactInfo", vo);
     }
 
@@ -43,9 +43,8 @@ public class ContactsAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param vo
      *            - 연락처 정보가 담긴 ContactsAndroidAPIVO
-     * @exception Exception
      */
-    public void updateContactsInfo(ContactsAndroidAPIVO vo) throws Exception {
+    public void updateContactsInfo(ContactsAndroidAPIVO vo) {
         insert("contactsAndroidAPIDAO.updateContactInfo", vo);
     }
 
@@ -54,9 +53,8 @@ public class ContactsAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param vo
      *            - 연락처 정보가 담긴 ContactsAndroidAPIVO
-     * @exception Exception
      */
-    public List<?> selectFileInfoList(ContactsAndroidAPIVO vo) throws Exception {
+    public List<?> selectFileInfoList(ContactsAndroidAPIVO vo) {
         return selectList("contactsAndroidAPIDAO.selectContactInfoList", vo);
     }
 
@@ -65,10 +63,8 @@ public class ContactsAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param vo
      *            - 연락처 정보가 담긴 ContactsAndroidAPIVO
-     * @exception Exception
      */
-    public ContactsAndroidAPIVO selectContactsInfo(ContactsAndroidAPIVO vo)
-            throws Exception {
+    public ContactsAndroidAPIVO selectContactsInfo(ContactsAndroidAPIVO vo) {
         return (ContactsAndroidAPIVO) selectOne(
                 "contactsAndroidAPIDAO.selectContactInfo", vo);
     }
@@ -78,9 +74,8 @@ public class ContactsAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param vo
      *            - 연락처 정보가 담긴 ContactsAndroidAPIVO
-     * @exception Exception
      */
-    public int deleteContactsInfo(ContactsAndroidAPIVO vo) throws Exception {
+    public int deleteContactsInfo(ContactsAndroidAPIVO vo) {
         return delete("contactsAndroidAPIDAO.deleteContactInfo", vo);
     }
 
@@ -89,9 +84,8 @@ public class ContactsAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param vo
      *            - 연락처 정보가 담긴 ContactsAndroidAPIVO
-     * @exception Exception
      */
-    public int selectContactsTotCnt(ContactsAndroidAPIVO vo) throws Exception {
+    public int selectContactsTotCnt(ContactsAndroidAPIVO vo) {
         return (Integer) selectOne(
                 "contactsAndroidAPIDAO.selectContactInfoListTotCnt", vo);
     }

--- a/web-guide/src/main/java/egovframework/hyb/add/dvc/service/impl/DeviceAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/dvc/service/impl/DeviceAndroidAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012.06.18    서형주                  최초생성
+ * @ 2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author Device API 실행환경팀
  * @since 2012. 07. 23
@@ -47,9 +48,8 @@ public class DeviceAndroidAPIDAO extends EgovComAbstractDAO {
      * 디바이스 정보를 등록한다.
      * @param vo - 등록할 정보가 담긴 DeviceAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertDeviceInfo(DeviceAndroidAPIVO vo) throws Exception {
+    public int insertDeviceInfo(DeviceAndroidAPIVO vo) {
         return (Integer)insert("deviceAndroidAPIDAO.insertDeviceInfo", vo);
     }
 
@@ -57,9 +57,8 @@ public class DeviceAndroidAPIDAO extends EgovComAbstractDAO {
      * 디바이스 정보를 수정한다.
      * @param vo - 수정할 정보가 담긴 DeviceAPIVO
      * @return void형
-     * @exception Exception
      */
-    public void updateDeviceInfo(DeviceAndroidAPIVO vo) throws Exception {
+    public void updateDeviceInfo(DeviceAndroidAPIVO vo) {
         update("deviceAndroidAPIDAO.updateDeviceInfo", vo);
     }
 
@@ -67,9 +66,8 @@ public class DeviceAndroidAPIDAO extends EgovComAbstractDAO {
      * 디바이스 정보를 삭제한다.
      * @param vo - 삭제할 정보가 담긴 DeviceAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int deleteDeviceInfo(DeviceAndroidAPIVO vo) throws Exception {
+    public int deleteDeviceInfo(DeviceAndroidAPIVO vo) {
         return (Integer)delete("deviceAndroidAPIDAO.deleteDeviceInfo", vo);
     }
 
@@ -77,9 +75,8 @@ public class DeviceAndroidAPIDAO extends EgovComAbstractDAO {
      * 디바이스 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 DeviceAPIVO
      * @return 조회한 디바이스 정보
-     * @exception Exception
      */
-    public DeviceAndroidAPIVO selectDeviceInfo(DeviceAndroidAPIVO vo) throws Exception {
+    public DeviceAndroidAPIVO selectDeviceInfo(DeviceAndroidAPIVO vo) {
         return (DeviceAndroidAPIVO) selectOne("deviceAndroidAPIDAO.selectDeviceInfo", vo);
     }
 
@@ -87,9 +84,8 @@ public class DeviceAndroidAPIDAO extends EgovComAbstractDAO {
      * 디바이스 정보 목록을 조회한다.
      * @param vo - 조회할 정보가 담긴 DeviceAPIDefaultVO
      * @return 디바이스 정보 목록
-     * @exception Exception
      */
-    public List<?> selectDeviceInfoList(DeviceAndroidAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectDeviceInfoList(DeviceAndroidAPIDefaultVO searchVO) {
         return selectList("deviceAndroidAPIDAO.selectDeviceInfoList", searchVO);
     }
 
@@ -97,7 +93,6 @@ public class DeviceAndroidAPIDAO extends EgovComAbstractDAO {
      * 디바이스 정보 총 갯수를 조회한다.
      * @param  vo - 조회할 정보가 담긴 DeviceAPIDefaultVO
      * @return 디바이스 정보 총 갯수
-     * @exception
      */
     public int selectDeviceInfoListTotCnt(DeviceAndroidAPIDefaultVO searchVO) {
         return (Integer) selectOne("deviceAndroidAPIDAO.selectDeviceInfoListTotCnt", searchVO);

--- a/web-guide/src/main/java/egovframework/hyb/add/frw/service/impl/FileReaderWriterAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/frw/service/impl/FileReaderWriterAndroidAPIDAO.java
@@ -17,6 +17,7 @@ import egovframework.hyb.add.frw.service.FileReaderWriterAndroidAPIVO;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012. 8. 6.  나신일                   최초생성
+ * @ 2026. 6. 26. 이백행                   [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 8. 6
@@ -33,10 +34,8 @@ public class FileReaderWriterAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param fileVO
      *            - 파일 정보가 담긴 FileReaderWriterAndroidAPIVO
-     * @exception Exception
      */
-    public void insertFileInfo(FileReaderWriterAndroidAPIVO vo)
-            throws Exception {
+    public void insertFileInfo(FileReaderWriterAndroidAPIVO vo) {
         insert("fileReaderWriterAndroidAPIDAO.insertFileInfo", vo);
     }
 
@@ -45,10 +44,8 @@ public class FileReaderWriterAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param fileVO
      *            - 파일 정보가 담긴 FileReaderWriterAndroidAPIVO
-     * @exception Exception
      */
-    public void insertFileDetailInfo(FileReaderWriterAndroidAPIVO vo)
-            throws Exception {
+    public void insertFileDetailInfo(FileReaderWriterAndroidAPIVO vo) {
         insert("fileReaderWriterAndroidAPIDAO.insertFileDetailInfo", vo);
     }
 
@@ -57,10 +54,8 @@ public class FileReaderWriterAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param fileVO
      *            - 파일 정보가 담긴 FileReaderWriterAndroidAPIVO
-     * @exception Exception
      */
-    public List<?> selectFileInfoList(FileReaderWriterAndroidAPIVO vo)
-            throws Exception {
+    public List<?> selectFileInfoList(FileReaderWriterAndroidAPIVO vo) {
         return selectList("fileReaderWriterAndroidAPIDAO.selectFileInfoList", vo);
     }
 
@@ -69,10 +64,9 @@ public class FileReaderWriterAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param fileVO
      *            - 파일 정보가 담긴 FileReaderWriterAndroidAPIVO
-     * @exception Exception
      */
     public FileReaderWriterAndroidAPIVO selectFileInfo(
-            FileReaderWriterAndroidAPIVO vo) throws Exception {
+            FileReaderWriterAndroidAPIVO vo) {
         return (FileReaderWriterAndroidAPIVO) selectOne(
                 "fileReaderWriterAndroidAPIDAO.selectFileInfo", vo);
     }
@@ -82,9 +76,8 @@ public class FileReaderWriterAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param fileVO
      *            - 파일 정보가 담긴 FileReaderWriterAndroidAPIVO
-     * @exception Exception
      */
-    public int deleteFileInfo(FileReaderWriterAndroidAPIVO vo) throws Exception {
+    public int deleteFileInfo(FileReaderWriterAndroidAPIVO vo) {
         return delete("fileReaderWriterAndroidAPIDAO.deleteFileInfo", vo);
     }
 
@@ -93,10 +86,8 @@ public class FileReaderWriterAndroidAPIDAO extends EgovComAbstractDAO {
      * 
      * @param fileVO
      *            - 파일 정보가 담긴 FileReaderWriterAndroidAPIVO
-     * @exception Exception
      */
-    public int deleteFileDetailInfo(FileReaderWriterAndroidAPIVO vo)
-            throws Exception {
+    public int deleteFileDetailInfo(FileReaderWriterAndroidAPIVO vo) {
         return delete("fileReaderWriterAndroidAPIDAO.deleteFileDetailInfo", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/add/gps/service/impl/GPSAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/gps/service/impl/GPSAndroidAPIDAO.java
@@ -33,6 +33,7 @@ import egovframework.hyb.add.gps.service.GPSAndroidAPIVO;
  * @ ----------   ---------   -------------------------------
  *   2012.08.27   나신일        최초생성
  *   2020.08.24   신용호        Swagger 적용
+ *   2026.06.26   이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 08.27
@@ -51,9 +52,8 @@ public class GPSAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 등록할 정보가 담긴 GPSAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertGPSInfo(GPSAndroidAPIVO vo) throws Exception {
+    public int insertGPSInfo(GPSAndroidAPIVO vo) {
         return (Integer) insert("gpsAndroidAPIDAO.insertGPSInfo", vo);
     }
 
@@ -63,9 +63,8 @@ public class GPSAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 삭제할 정보가 담긴 GPSAPIVO
      * @return void형
-     * @exception Exception
      */
-    public int deleteGPSInfo(GPSAndroidAPIVO vo) throws Exception {
+    public int deleteGPSInfo(GPSAndroidAPIVO vo) {
         return delete("gpsAndroidAPIDAO.deleteGPSInfo", vo);
     }
 
@@ -75,9 +74,8 @@ public class GPSAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 조회할 정보가 담긴 GPSAPIDefaultVO
      * @return gps 정보 목록
-     * @exception Exception
      */
-    public List<?> selectGPSInfoList(GPSAndroidAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectGPSInfoList(GPSAndroidAPIDefaultVO searchVO) {
         return selectList("gpsAndroidAPIDAO.selectGPSInfoList", searchVO);
     }
 
@@ -87,7 +85,6 @@ public class GPSAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 조회할 정보가 담긴 GPSAPIDefaultVO
      * @return 네트워크 정보 총 갯수
-     * @exception
      */
     public int selectGPSInfoListTotCnt(GPSAndroidAPIDefaultVO searchVO) {
         return (Integer) selectOne(

--- a/web-guide/src/main/java/egovframework/hyb/add/itf/service/impl/InterfaceAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/itf/service/impl/InterfaceAndroidAPIDAO.java
@@ -29,6 +29,7 @@ import egovframework.hyb.add.itf.service.InterfaceAndroidAPIVO;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012.07.09    나신일                  최초생성
+ * @ 2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 모바일 디바이스 API 팀
  * @since 2012. 07. 09
@@ -47,7 +48,6 @@ public class InterfaceAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 조회할 정보가 담긴 InterfaceAndroidAPIVO
      * @return 인터페이스 정보 갯수
-     * @exception
      */
     public int selectInterfaceInfoListTotCnt(InterfaceAndroidAPIVO vo) {
         return (Integer) selectOne(
@@ -60,9 +60,8 @@ public class InterfaceAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 등록할 정보가 담긴 InterfaceAndroidAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertInterfaceInfo(InterfaceAndroidAPIVO vo) throws Exception {
+    public int insertInterfaceInfo(InterfaceAndroidAPIVO vo) {
         return (Integer) insert("interfaceAndroidAPIDAO.insertInterfaceInfo",
                 vo);
     }
@@ -73,10 +72,8 @@ public class InterfaceAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 로그인할 정보가 담긴 InterfaceAndroidAPIVO
      * @return 로그인 결과
-     * @exception Exception
      */
-    public InterfaceAndroidAPIVO selectInterfaceInfo(InterfaceAndroidAPIVO vo)
-            throws Exception {
+    public InterfaceAndroidAPIVO selectInterfaceInfo(InterfaceAndroidAPIVO vo) {
         return (InterfaceAndroidAPIVO) selectOne(
                 "interfaceAndroidAPIDAO.selectInterfaceInfo", vo);
     }
@@ -87,9 +84,8 @@ public class InterfaceAndroidAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 탈퇴할 정보가 담긴 InterfaceAndroidAPIVO
      * @return 회원탈퇴 결과
-     * @exception Exception
      */
-    public int deleteInterfaceInfo(InterfaceAndroidAPIVO vo) throws Exception {
+    public int deleteInterfaceInfo(InterfaceAndroidAPIVO vo) {
         return delete("interfaceAndroidAPIDAO.deleteInterfaceInfo", vo);
     }
 

--- a/web-guide/src/main/java/egovframework/hyb/add/mda/service/impl/MediaAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/mda/service/impl/MediaAndroidAPIDAO.java
@@ -31,6 +31,7 @@ import egovframework.hyb.add.mda.service.MediaAndroidAPIVO;
  * @  수정일            수정자        수정내용
  * @ ---------        ---------    -------------------------------
  * @ 2012. 7. 30.        이율경        최초생성
+ * @ 2026. 6. 26.        이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 팀
  * @since 2012. 7. 30.
@@ -45,9 +46,8 @@ public class MediaAndroidAPIDAO extends EgovComAbstractDAO {
      * 녹음 Media를 등록한다.
      * @param vo - 등록할 정보가 담긴 CameraAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertMediaInfo(MediaAndroidAPIFileVO vo) throws Exception {
+    public int insertMediaInfo(MediaAndroidAPIFileVO vo) {
         return (Integer)insert("mediaAndroidAPIDAO.insertMediaInfo", vo);
     }
     
@@ -55,9 +55,8 @@ public class MediaAndroidAPIDAO extends EgovComAbstractDAO {
      * 녹음 파일을 등록한다.
      * @param vo - 등록할 파일 정보가 담긴 CameraAndroidAPIFileVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertMediaRecordFile(MediaAndroidAPIFileVO vo) throws Exception {
+    public int insertMediaRecordFile(MediaAndroidAPIFileVO vo) {
         return (Integer)insert("mediaAndroidAPIDAO.insertMediaRecordFile", vo);
     }
     
@@ -65,9 +64,8 @@ public class MediaAndroidAPIDAO extends EgovComAbstractDAO {
      * 녹음 재생횟수를 수정한다.
      * @param vo - 등록할 정보가 담긴 MediaAndroidAPIFileVO
      * @return 수정 결과
-     * @exception Exception
      */
-    public int updateMediaInfoRevivCo(MediaAndroidAPIVO vo) throws Exception {
+    public int updateMediaInfoRevivCo(MediaAndroidAPIVO vo) {
         return (Integer)update("mediaAndroidAPIDAO.updateMediaInfoRevivCo", vo);
     }
     
@@ -75,9 +73,8 @@ public class MediaAndroidAPIDAO extends EgovComAbstractDAO {
      * 미디어 정보를 조회한다.
      * @param VO - 조회할 정보가 담긴 MediaAndroidAPIVO
      * @return 조회 목록
-     * @exception Exception
      */
-    public MediaAndroidAPIFileVO selectMediaInfoDetail(MediaAndroidAPIVO vo) throws Exception {
+    public MediaAndroidAPIFileVO selectMediaInfoDetail(MediaAndroidAPIVO vo) {
         return (MediaAndroidAPIFileVO) selectOne("mediaAndroidAPIDAO.selectMediaInfoDetail", vo);
     }
     
@@ -85,9 +82,8 @@ public class MediaAndroidAPIDAO extends EgovComAbstractDAO {
      * 미디어 목록을 조회한다.
      * @param VO - 조회할 정보가 담긴 MediaAndroidAPIDefaultVO
      * @return 조회 목록
-     * @exception Exception
      */
-    public List<?> selectMediaInfoList(MediaAndroidAPIVO searchVO) throws Exception {
+    public List<?> selectMediaInfoList(MediaAndroidAPIVO searchVO) {
         return selectList("mediaAndroidAPIDAO.selectMediaInfoList", searchVO);
     }
     
@@ -95,9 +91,8 @@ public class MediaAndroidAPIDAO extends EgovComAbstractDAO {
      * 미디어 파일 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 MediaAndroidAPIFileVO
      * @return 이미지 파일 정보
-     * @exception Exception
      */
-    public MediaAndroidAPIFileVO selectMediaFileInfo(MediaAndroidAPIFileVO vo) throws Exception {
+    public MediaAndroidAPIFileVO selectMediaFileInfo(MediaAndroidAPIFileVO vo) {
         return (MediaAndroidAPIFileVO) selectOne("mediaAndroidAPIDAO.selectMediaFileInfo", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/add/nwk/service/impl/NetworkAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/nwk/service/impl/NetworkAndroidAPIDAO.java
@@ -31,6 +31,7 @@ import egovframework.hyb.add.nwk.service.NetworkAndroidAPIVO;
  * @  수정일            수정자        수정내용
  * @ ---------        ---------    -------------------------------
  * @ 2012. 8. 20.        이율경        최초생성
+ * @ 2026. 6. 26.        이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 팀
  * @since 2012. 8. 20.
@@ -45,9 +46,8 @@ public class NetworkAndroidAPIDAO extends EgovComAbstractDAO {
      * 네트워크 정보를 등록한다.
      * @param vo - 등록할 정보가 담긴 NetworkAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertNetworkInfo(NetworkAndroidAPIVO vo) throws Exception {
+    public int insertNetworkInfo(NetworkAndroidAPIVO vo) {
         return (Integer)insert("networkAndroidAPIDAO.insertNetworkInfo", vo);
     }
 
@@ -55,9 +55,8 @@ public class NetworkAndroidAPIDAO extends EgovComAbstractDAO {
      * 네트워크 정보를 수정한다.
      * @param vo - 수정할 정보가 담긴 NetworkAPIVO
      * @return void형
-     * @exception Exception
      */
-    public int updateNetworkInfo(NetworkAndroidAPIVO vo) throws Exception {
+    public int updateNetworkInfo(NetworkAndroidAPIVO vo) {
         return (Integer)update("networkAndroidAPIDAO.updateNetworkInfo", vo);
     }
 
@@ -65,9 +64,8 @@ public class NetworkAndroidAPIDAO extends EgovComAbstractDAO {
      * 네트워크 정보를 삭제한다.
      * @param vo - 삭제할 정보가 담긴 NetworkAPIVO
      * @return void형 
-     * @exception Exception
      */
-    public int deleteNetworkInfo(NetworkAndroidAPIVO vo) throws Exception {
+    public int deleteNetworkInfo(NetworkAndroidAPIVO vo) {
         return (Integer)delete("networkAndroidAPIDAO.deleteNetworkInfo", vo);
     }
 
@@ -75,9 +73,8 @@ public class NetworkAndroidAPIDAO extends EgovComAbstractDAO {
      * 네트워크 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 NetworkAPIVO
      * @return 조회한 네트워크 정보
-     * @exception Exception
      */
-    public NetworkAndroidAPIVO selectNetworkInfo(NetworkAndroidAPIVO vo) throws Exception {
+    public NetworkAndroidAPIVO selectNetworkInfo(NetworkAndroidAPIVO vo) {
         return (NetworkAndroidAPIVO) selectOne("networkAndroidAPIDAO.selectNetworkInfo", vo);
     }
 
@@ -85,9 +82,8 @@ public class NetworkAndroidAPIDAO extends EgovComAbstractDAO {
      * 네트워크 정보 목록을 조회한다.
      * @param vo - 조회할 정보가 담긴 NetworkAPIDefaultVO
      * @return 네트워크 정보 목록
-     * @exception Exception
      */
-    public List<?> selectNetworkInfoList(NetworkAndroidAPIDefaultVO searchNetworkVO) throws Exception {
+    public List<?> selectNetworkInfoList(NetworkAndroidAPIDefaultVO searchNetworkVO) {
         return selectList("networkAndroidAPIDAO.selectNetworkInfoList", searchNetworkVO);
         //return null;
     }
@@ -96,7 +92,6 @@ public class NetworkAndroidAPIDAO extends EgovComAbstractDAO {
      * 네트워크 정보 총 갯수를 조회한다.
      * @param  vo - 조회할 정보가 담긴 NetworkAPIDefaultVO
      * @return 네트워크 정보 총 갯수
-     * @exception
      */
     public int selectNetworkInfoListTotCnt(NetworkAndroidAPIDefaultVO searchVO) {
         return (Integer) selectOne("networkAPIDAO.selectNetworkInfoListTotCnt_S", searchVO);

--- a/web-guide/src/main/java/egovframework/hyb/add/vbr/service/impl/VibratorAndroidAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/add/vbr/service/impl/VibratorAndroidAPIDAO.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일            수정자        수정내용
  * @ ---------        ---------    -------------------------------
  * @ 2012. 8. 16.        이율경        최초생성
+ * @ 2026. 6. 26.        이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 팀
  * @since 2012. 8. 16.
@@ -45,9 +46,8 @@ public class VibratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 알람 정보를 등록한다.
      * @param vo - 등록할 정보가 담긴 VibratorAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertVibrator(VibratorAndroidAPIVO vo) throws Exception {
+    public int insertVibrator(VibratorAndroidAPIVO vo) {
         return (Integer)insert("vibratorAndroidAPIDAO.insertVibrator", vo);
     }
 
@@ -55,9 +55,8 @@ public class VibratorAndroidAPIDAO extends EgovComAbstractDAO {
      * 알람 정보 목록을 조회한다.
      * @param vo - 조회할 정보가 담긴 VibratorAPIDefaultVO
      * @return 네트워크 정보 목록
-     * @exception Exception
      */
-    public List<?> selectVibratorList(VibratorAndroidAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectVibratorList(VibratorAndroidAPIDefaultVO searchVO) {
         return selectList("vibratorAndroidAPIDAO.selectVibratorList", searchVO);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/ios/acl/service/imp/AcceleratoriOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/acl/service/imp/AcceleratoriOSAPIDAO.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Repository;
  * @ ---------   ---------   -------------------------------
  * @ 2012.07.23    서형주                  최초생성
  *   2012.08.16    서준식                 json 버전으로 변경 
+ *   2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author Device API 실행환경팀
  * @since 2012. 07. 23
@@ -48,9 +49,8 @@ public class AcceleratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 가속도 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 AcceleratoriOSAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertAcceleratorInfo(AcceleratoriOSAPIVO vo) throws Exception {
+    public int insertAcceleratorInfo(AcceleratoriOSAPIVO vo) {
     	return (Integer)insert("acceleratoriOSAPIDAO.insertAcceleratorInfo", vo);
     }
 
@@ -58,9 +58,8 @@ public class AcceleratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 가속도 정보를 수정한다.
 	 * @param vo - 수정할 정보가 담긴 AcceleratoriOSAPIVO
 	 * @return void형
-	 * @exception Exception
 	 */
-    public void updateAcceleratorInfo(AcceleratoriOSAPIVO vo) throws Exception {
+    public void updateAcceleratorInfo(AcceleratoriOSAPIVO vo) {
         update("acceleratoriOSAPIDAO.updateAcceleratorInfo", vo);
     }
 
@@ -68,9 +67,8 @@ public class AcceleratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 가속도 정보를 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 AcceleratoriOSAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int deleteAcceleratorInfo(AcceleratoriOSAPIVO vo) throws Exception {
+    public int deleteAcceleratorInfo(AcceleratoriOSAPIVO vo) {
     	return (Integer)delete("acceleratoriOSAPIDAO.deleteAcceleratorInfo", vo);
     }
 
@@ -78,9 +76,8 @@ public class AcceleratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 가속도 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 AcceleratoriOSAPIVO
 	 * @return 조회한 가속도 정보
-	 * @exception Exception
 	 */
-    public AcceleratoriOSAPIVO selectAcceleratorInfo(AcceleratoriOSAPIVO vo) throws Exception {
+    public AcceleratoriOSAPIVO selectAcceleratorInfo(AcceleratoriOSAPIVO vo) {
         return (AcceleratoriOSAPIVO) selectOne("acceleratoriOSAPIDAO.selectAcceleratorInfo", vo);
     }
 
@@ -88,9 +85,8 @@ public class AcceleratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 가속도 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 AcceleratoriOSAPIDefaultVO
 	 * @return 가속도 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectAcceleratorInfoList(AcceleratoriOSAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectAcceleratorInfoList(AcceleratoriOSAPIDefaultVO searchVO) {
         return selectList("acceleratoriOSAPIDAO.selectAcceleratorInfoList", searchVO);
     }
 
@@ -98,7 +94,6 @@ public class AcceleratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 가속도 정보 총 갯수를 조회한다.
 	 * @param  vo - 조회할 정보가 담긴 AcceleratoriOSAPIDefaultVO
 	 * @return 가속도 정보 총 갯수
-	 * @exception
 	 */
     public int selectAcceleratorInfoListTotCnt(AcceleratoriOSAPIDefaultVO searchVO) {
         return (Integer) selectOne("acceleratoriOSAPIDAO.selectAcceleratorInfoListTotCnt", searchVO);

--- a/web-guide/src/main/java/egovframework/hyb/ios/cmr/service/impl/CameraiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/cmr/service/impl/CameraiOSAPIDAO.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Repository;
  * @ ---------		---------	-------------------------------
  * @ 2012. 7. 23.		이율경		최초생성
  * @ 2012. 8. 03.  		이해성       커스터마이징
+ * @ 2026. 6. 26.       이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 개발환경 팀
  * @since 2012. 7. 23.
@@ -47,9 +48,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 CameraAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertCameraPhotoAlbum(CameraiOSAPIFileVO vo) throws Exception {
+    public int insertCameraPhotoAlbum(CameraiOSAPIFileVO vo) {
     	return (Integer)insert("cameraiOSAPIDAO.insertCameraPhotoAlbum", vo);
     }
     
@@ -57,9 +57,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 파일을 등록한다.
 	 * @param vo - 등록할 파일 정보가 담긴 CameraIOSAPIFileVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertCameraPhotoAlbumFile(CameraiOSAPIFileVO vo) throws Exception {
+    public int insertCameraPhotoAlbumFile(CameraiOSAPIFileVO vo) {
     	return (Integer)insert("cameraiOSAPIDAO.insertCameraPhotoAlbumFile", vo);
     }
     
@@ -67,9 +66,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 파일을 수정한다.
 	 * @param vo - 등록할 정보가 담긴 CameraIOSAPIFileVO
 	 * @return 수정 결과
-	 * @exception Exception
 	 */
-    public int updateCameraPhotoAlbumInfoFile(CameraiOSAPIFileVO vo) throws Exception {
+    public int updateCameraPhotoAlbumInfoFile(CameraiOSAPIFileVO vo) {
     	return (Integer)update("cameraiOSAPIDAO.updateCameraPhotoAlbumFile", vo);
     }
 
@@ -77,9 +75,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지를 삭제한다.
 	 * @param vo - 삭제할 파일 정보가 담긴 CameraAPIVO
 	 * @return 삭제 결과
-	 * @exception Exception
 	 */
-    public int deleteCameraPhotoAlbumInfo(CameraiOSAPIVO vo) throws Exception {
+    public int deleteCameraPhotoAlbumInfo(CameraiOSAPIVO vo) {
     	return (Integer)delete("cameraiOSAPIDAO.deleteCameraPhotoAlbumInfo", vo);
     }
     
@@ -87,9 +84,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 파일을  삭제한다.
 	 * @param vo - 삭제할 파일 정보가 담긴 CameraIOSAPIFileVO
 	 * @return 삭제 결과 
-	 * @exception Exception
 	 */
-    public int deleteCameraPhotoAlbumInfoFile(CameraiOSAPIVO vo) throws Exception {
+    public int deleteCameraPhotoAlbumInfoFile(CameraiOSAPIVO vo) {
     	return (Integer)delete("cameraiOSAPIDAO.deleteCameraPhotoAlbumInfoFile", vo);
     }
 
@@ -97,9 +93,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 CameraAPIVO
 	 * @return 조회한 네트워크 정보
-	 * @exception Exception
 	 */
-    public CameraiOSAPIVO selectCameraPhotoAlbumInfo(CameraiOSAPIVO vo) throws Exception {
+    public CameraiOSAPIVO selectCameraPhotoAlbumInfo(CameraiOSAPIVO vo) {
         return (CameraiOSAPIVO) selectOne("cameraiOSAPIDAO.selectCameraPhotoAlbumInfo", vo);
     }
 
@@ -107,9 +102,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 CameraAPIDefaultVO
 	 * @return 이미지 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectCameraPhotoAlbumInfoList(CameraiOSAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectCameraPhotoAlbumInfoList(CameraiOSAPIDefaultVO searchVO) {
         return selectList("cameraiOSAPIDAO.selectCameraPhotoAlbumInfoList", searchVO);
     }
     
@@ -117,9 +111,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 파일 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 CameraIOSAPIFileVO
 	 * @return 이미지 파일 정보
-	 * @exception Exception
 	 */
-    public CameraiOSAPIFileVO selectImageFileInfo(CameraiOSAPIFileVO vo) throws Exception {
+    public CameraiOSAPIFileVO selectImageFileInfo(CameraiOSAPIFileVO vo) {
         return (CameraiOSAPIFileVO) selectOne("cameraiOSAPIDAO.selectImageFileInfo", vo);
     }
     
@@ -127,9 +120,8 @@ public class CameraiOSAPIDAO extends EgovComAbstractDAO {
 	 * 이미지 제목 중복을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 CameraIOSAPIFileVO
 	 * @return 파일연번 정보
-	 * @exception Exception
 	 */
-    public CameraiOSAPIFileVO selectPhotoAlbumPhotoSj(CameraiOSAPIFileVO vo) throws Exception {
+    public CameraiOSAPIFileVO selectPhotoAlbumPhotoSj(CameraiOSAPIFileVO vo) {
         return (CameraiOSAPIFileVO) selectOne("cameraiOSAPIDAO.selectCameraPhotoAlbumPhotoSj", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/ios/cps/service/impl/CompassiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/cps/service/impl/CompassiOSAPIDAO.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Repository;
  * @ ---------   ---------   -------------------------------
  * @ 2012.06.18    서형주                  최초생성
  *   2012.08.27    서준식             iOS용 패키지로 변경 
+ *   2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * @author Device API 실행환경팀
  * @since 2012. 07. 30
  * @version 1.0
@@ -47,9 +48,8 @@ public class CompassiOSAPIDAO extends EgovComAbstractDAO {
 	 * 방향 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 CompassiOSAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertCompassInfo(CompassiOSAPIVO vo) throws Exception {
+    public int insertCompassInfo(CompassiOSAPIVO vo) {
     	return (Integer)insert("compassiOSAPIDAO.insertCompassInfo", vo);
     }
 
@@ -57,9 +57,8 @@ public class CompassiOSAPIDAO extends EgovComAbstractDAO {
 	 * 방향 정보를 수정한다.
 	 * @param vo - 수정할 정보가 담긴 CompassiOSAPIVO
 	 * @return void형
-	 * @exception Exception
 	 */
-    public void updateCompassInfo(CompassiOSAPIVO vo) throws Exception {
+    public void updateCompassInfo(CompassiOSAPIVO vo) {
         update("compassiOSAPIDAO.updateCompassInfo", vo);
     }
 
@@ -67,9 +66,8 @@ public class CompassiOSAPIDAO extends EgovComAbstractDAO {
 	 * 방향 정보를 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 CompassiOSAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int deleteCompassInfo(CompassiOSAPIVO vo) throws Exception {
+    public int deleteCompassInfo(CompassiOSAPIVO vo) {
     	return (Integer)delete("compassiOSAPIDAO.deleteCompassInfo", vo);
     }
 
@@ -77,9 +75,8 @@ public class CompassiOSAPIDAO extends EgovComAbstractDAO {
 	 * 방향 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 CompassiOSAPIVO
 	 * @return 조회한 방향 정보
-	 * @exception Exception
 	 */
-    public CompassiOSAPIVO selectCompassInfo(CompassiOSAPIVO vo) throws Exception {
+    public CompassiOSAPIVO selectCompassInfo(CompassiOSAPIVO vo) {
         return (CompassiOSAPIVO) selectOne("compassiOSAPIDAO.selectCompassInfo", vo);
     }
 
@@ -87,9 +84,8 @@ public class CompassiOSAPIDAO extends EgovComAbstractDAO {
 	 * 방향 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 CompassiOSAPIDefaultVO
 	 * @return 방향 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectCompassInfoList(CompassiOSAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectCompassInfoList(CompassiOSAPIDefaultVO searchVO) {
         return selectList("compassiOSAPIDAO.selectCompassInfoList", searchVO);
     }
 
@@ -97,7 +93,6 @@ public class CompassiOSAPIDAO extends EgovComAbstractDAO {
 	 * 방향 정보 총 갯수를 조회한다.
 	 * @param  vo - 조회할 정보가 담긴 CompassiOSAPIDefaultVO
 	 * @return 방향 정보 총 갯수
-	 * @exception
 	 */
     public int selectCompassInfoListTotCnt(CompassiOSAPIDefaultVO searchVO) {
         return (Integer) selectOne("compassiOSAPIDAO.selectCompassInfoListTotCnt", searchVO);

--- a/web-guide/src/main/java/egovframework/hyb/ios/ctt/service/impl/ContactsiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/ctt/service/impl/ContactsiOSAPIDAO.java
@@ -18,6 +18,7 @@ import egovframework.hyb.ios.ctt.service.ContactsiOSAPIVO;
  * @ ---------   ---------   -------------------------------
  * @ 2012. 8. 13.  나신일                   최초생성
  * @ 2012. 8. 23.  이해성                   커스터마이징
+ *   2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 8. 13
@@ -32,9 +33,8 @@ public class ContactsiOSAPIDAO extends EgovComAbstractDAO{
 	/**
 	 * 연락처  정보를 입력한다.
 	 * @param vo - 연락처 정보가 담긴 ContactsiOSAPIVO 
-	 * @exception Exception
 	 */
-    public void insertContactsInfo(ContactsiOSAPIVO vo) throws Exception {
+    public void insertContactsInfo(ContactsiOSAPIVO vo) {
         insert("contactsiOSAPIDAO.insertContactInfo", vo);
     }
     
@@ -42,45 +42,40 @@ public class ContactsiOSAPIDAO extends EgovComAbstractDAO{
     /**
 	 * 연락처 정보를 업데이트 한다.
 	 * @param vo - 연락처 정보가 담긴 ContactsiOSAPIVO 
-	 * @exception Exception
 	 */
-    public void updateContactsInfo(ContactsiOSAPIVO vo) throws Exception {
+    public void updateContactsInfo(ContactsiOSAPIVO vo) {
         insert("contactsiOSAPIDAO.updateContactInfo", vo);
     }
     
     /**
 	 * 연락처 정보리스트를 조회한다.
 	 * @param vo - 연락처 정보가 담긴 ContactsiOSAPIVO 
-	 * @exception Exception
 	 */
-    public List<?> selectFileInfoList(ContactsiOSAPIVO vo) throws Exception{
+    public List<?> selectFileInfoList(ContactsiOSAPIVO vo) {
     	return selectList("contactsiOSAPIDAO.selectContactInfoList", vo);
     }
     
     /**
 	 * 연락처 정보를 조회한다.
 	 * @param vo - 연락처 정보가 담긴 ContactsiOSAPIVO 
-	 * @exception Exception
 	 */
-    public ContactsiOSAPIVO selectContactsInfo(ContactsiOSAPIVO vo) throws Exception{
+    public ContactsiOSAPIVO selectContactsInfo(ContactsiOSAPIVO vo) {
     	return (ContactsiOSAPIVO) selectOne("contactsiOSAPIDAO.selectContactInfo", vo);
     }
     
     /**
 	 * 연락처 정보를 삭제한다.
 	 * @param vo - 연락처 정보가 담긴 ContactsiOSAPIVO 
-	 * @exception Exception
 	 */
-    public int deleteContactsInfo(ContactsiOSAPIVO vo) throws Exception {
+    public int deleteContactsInfo(ContactsiOSAPIVO vo) {
     	return delete("contactsiOSAPIDAO.deleteContactInfo", vo);
     }
     
     /**
 	 * 연락처 정보를 삭제한다.
 	 * @param vo - 연락처 정보가 담긴 ContactsiOSAPIVO 
-	 * @exception Exception
 	 */
-    public int selectContactsTotCnt(ContactsiOSAPIVO vo) throws Exception {
+    public int selectContactsTotCnt(ContactsiOSAPIVO vo) {
     	return (Integer) selectOne("contactsiOSAPIDAO.selectContactInfoListTotCnt", vo);    	
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/ios/dvc/service/impl/DeviceiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/dvc/service/impl/DeviceiOSAPIDAO.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일      수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012.07.30   서준식                 최초생성
+ *   2026.06.26   이백행                 [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 07.30
@@ -47,9 +48,8 @@ public class DeviceiOSAPIDAO extends EgovComAbstractDAO {
 	 * 디바이스 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 DeviceiOSAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public void insertDeviceInfo(DeviceiOSAPIVO vo) throws Exception {
+    public void insertDeviceInfo(DeviceiOSAPIVO vo) {
         insert("deviceiOSAPIDAO.insertDeviceInfo", vo);
     }
 
@@ -59,9 +59,8 @@ public class DeviceiOSAPIDAO extends EgovComAbstractDAO {
 	 * 디바이스 정보를 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 DeviceiOSAPIVO
 	 * @return void형 
-	 * @exception Exception
 	 */
-    public void deleteDeviceInfo(DeviceiOSAPIVO vo) throws Exception {
+    public void deleteDeviceInfo(DeviceiOSAPIVO vo) {
         delete("deviceiOSAPIDAO.deleteDeviceInfo", vo);
     }
 
@@ -69,9 +68,8 @@ public class DeviceiOSAPIDAO extends EgovComAbstractDAO {
 	 * 디바이스 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 DeviceiOSAPIVO
 	 * @return 조회한 디바이스 정보
-	 * @exception Exception
 	 */
-    public DeviceiOSAPIVO selectDeviceInfo(DeviceiOSAPIVO vo) throws Exception {
+    public DeviceiOSAPIVO selectDeviceInfo(DeviceiOSAPIVO vo) {
         return (DeviceiOSAPIVO) selectOne("deviceiOSAPIDAO.selectDeviceInfo", vo);
     }
 
@@ -79,9 +77,8 @@ public class DeviceiOSAPIDAO extends EgovComAbstractDAO {
 	 * 디바이스 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 DeviceiOSAPIVO
 	 * @return 디바이스 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectDeviceInfoList(DeviceiOSAPIVO vo) throws Exception {
+    public List<?> selectDeviceInfoList(DeviceiOSAPIVO vo) {
         return selectList("deviceiOSAPIDAO.selectDeviceInfoList", vo);
     }
 
@@ -89,7 +86,6 @@ public class DeviceiOSAPIDAO extends EgovComAbstractDAO {
 	 * 디바이스 정보 총 갯수를 조회한다.
 	 * @param  vo - 조회할 정보가 담긴 DeviceiOSAPIVO
 	 * @return 디바이스 정보 총 갯수
-	 * @exception
 	 */
     public int selectDeviceInfoListTotCnt(DeviceiOSAPIVO vo) {
         return (Integer) selectOne("deviceiOSAPIDAO.selectDeviceInfoListTotCnt", vo);

--- a/web-guide/src/main/java/egovframework/hyb/ios/frw/service/impl/FileReaderWriteriOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/frw/service/impl/FileReaderWriteriOSAPIDAO.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일                 수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012. 7. 10.  서준식                  최초생성
+ * @ 2026. 6. 26.  이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 7. 10.
@@ -32,9 +33,8 @@ public class FileReaderWriteriOSAPIDAO extends EgovComAbstractDAO{
 	/**
 	 * 파일  정보를 입력한다.
 	 * @param fileVO - 파일 정보가 담긴 FileReaderWriteriOSAPIVO 
-	 * @exception Exception
 	 */
-    public void insertFileInfo(FileReaderWriteriOSAPIVO vo) throws Exception {
+    public void insertFileInfo(FileReaderWriteriOSAPIVO vo) {
         insert("fileReaderWriteriOSAPIDAO.insertFileInfo", vo);
     }
     
@@ -42,36 +42,32 @@ public class FileReaderWriteriOSAPIDAO extends EgovComAbstractDAO{
     /**
 	 * 업로드 된 파일의 상세 정보를 저장한다.
 	 * @param fileVO - 파일 정보가 담긴 FileReaderWriteriOSAPIVO 
-	 * @exception Exception
 	 */
-    public void insertFileDetailInfo(FileReaderWriteriOSAPIVO vo) throws Exception {
+    public void insertFileDetailInfo(FileReaderWriteriOSAPIVO vo) {
         insert("fileReaderWriteriOSAPIDAO.insertFileDetailInfo", vo);
     }
     
     /**
 	 * 파일 정보리스트를 조회한다.
 	 * @param fileVO - 파일 정보가 담긴 FileReaderWriteriOSAPIVO 
-	 * @exception Exception
 	 */
-    public List<?> selectFileInfoList(FileReaderWriteriOSAPIVO vo) throws Exception{
+    public List<?> selectFileInfoList(FileReaderWriteriOSAPIVO vo) {
     	return selectList("fileReaderWriteriOSAPIDAO.selectFileInfoList", vo);
     }
     
     /**
 	 * 파일 정보를 조회한다.
 	 * @param fileVO - 파일 정보가 담긴 FileReaderWriteriOSAPIVO 
-	 * @exception Exception
 	 */
-    public FileReaderWriteriOSAPIVO selectFileInfo(FileReaderWriteriOSAPIVO vo) throws Exception{
+    public FileReaderWriteriOSAPIVO selectFileInfo(FileReaderWriteriOSAPIVO vo) {
     	return (FileReaderWriteriOSAPIVO) selectOne("fileReaderWriteriOSAPIDAO.selectFileInfo", vo);
     }
     
     /**
 	 * 파일 정보를 삭제한다.
 	 * @param fileVO - 파일 정보가 담긴 FileReaderWriteriOSAPIVO 
-	 * @exception Exception
 	 */
-    public void deleteFileInfo(FileReaderWriteriOSAPIVO vo) throws Exception {
+    public void deleteFileInfo(FileReaderWriteriOSAPIVO vo) {
     	delete("fileReaderWriteriOSAPIDAO.deleteFileInfo", vo);
     }
     
@@ -79,9 +75,8 @@ public class FileReaderWriteriOSAPIDAO extends EgovComAbstractDAO{
     /**
 	 * 파일 디테일 정보를 삭제한다.
 	 * @param fileVO - 파일 정보가 담긴 FileReaderWriteriOSAPIVO 
-	 * @exception Exception
 	 */
-    public void deleteFileDetailInfo(FileReaderWriteriOSAPIVO vo) throws Exception {
+    public void deleteFileDetailInfo(FileReaderWriteriOSAPIVO vo) {
     	delete("fileReaderWriteriOSAPIDAO.deleteFileDetailInfo", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/ios/gps/service/impl/GPSiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/gps/service/impl/GPSiOSAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일              수정자                 수정내용
  * @ 
  * @ 2012.07.31   이한철                 최초생성
+ *   2026.06.26   이백행                 [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 05. 14
@@ -50,9 +51,8 @@ public class GPSiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 등록할 정보가 담긴 GPSAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public void insertGPSInfo(GPSiOSAPIVO vo) throws Exception {
+    public void insertGPSInfo(GPSiOSAPIVO vo) {
         insert("gpsiOSAPIDAO.insertGPSInfo", vo);
     }
 
@@ -62,9 +62,8 @@ public class GPSiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 삭제할 정보가 담긴 GPSAPIVO
      * @return void형
-     * @exception Exception
      */
-    public void deleteGPSInfo(GPSiOSAPIVO vo) throws Exception {
+    public void deleteGPSInfo(GPSiOSAPIVO vo) {
         delete("gpsiOSAPIDAO.deleteGPSInfo", vo);
     }
 
@@ -74,9 +73,8 @@ public class GPSiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 조회할 정보가 담긴 GPSAPIDefaultVO
      * @return gps 정보 목록
-     * @exception Exception
      */
-    public List<?> selectGPSInfoList(GPSiOSAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectGPSInfoList(GPSiOSAPIDefaultVO searchVO) {
         return selectList("gpsiOSAPIDAO.selectGPSInfoList", searchVO);
     }
 
@@ -86,7 +84,6 @@ public class GPSiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 조회할 정보가 담긴 GPSAPIDefaultVO
      * @return 네트워크 정보 총 갯수
-     * @exception
      */
     public int selectGPSInfoListTotCnt(GPSiOSAPIDefaultVO searchVO) {
         return (Integer) selectOne(

--- a/web-guide/src/main/java/egovframework/hyb/ios/itf/service/impl/InterfaceiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/itf/service/impl/InterfaceiOSAPIDAO.java
@@ -29,6 +29,7 @@ import egovframework.hyb.ios.itf.service.InterfaceiOSAPIVO;
  * @  수정일                 수정자                 수정내용
  * @ 
  * @ 2012.07.11    이한철                  최초생성
+ *   2026.06.26    이백행                  [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 모바일 디바이스 API 팀
  * @since 2012. 07. 11
@@ -47,7 +48,6 @@ public class InterfaceiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 조회할 정보가 담긴 InterfaceiOSAPIVO
      * @return 인터페이스 정보 갯수
-     * @exception
      */
     public int selectInterfaceInfoListTotCnt(InterfaceiOSAPIVO vo) {
         return (Integer) selectOne(
@@ -60,9 +60,8 @@ public class InterfaceiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 등록할 정보가 담긴 InterfaceiOSAPIVO
      * @return 등록 결과
-     * @exception Exception
      */
-    public int insertInterfaceInfo(InterfaceiOSAPIVO vo) throws Exception {
+    public int insertInterfaceInfo(InterfaceiOSAPIVO vo) {
         return (Integer) insert("interfaceiOSAPIDAO.insertInterfaceInfo", vo);
     }
 
@@ -72,10 +71,8 @@ public class InterfaceiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 로그인할 정보가 담긴 InterfaceiOSAPIVO
      * @return 로그인 결과
-     * @exception Exception
      */
-    public InterfaceiOSAPIVO selectInterfaceInfo(InterfaceiOSAPIVO vo)
-            throws Exception {
+    public InterfaceiOSAPIVO selectInterfaceInfo(InterfaceiOSAPIVO vo) {
         return (InterfaceiOSAPIVO) selectOne(
                 "interfaceiOSAPIDAO.selectInterfaceInfo", vo);
     }
@@ -86,9 +83,8 @@ public class InterfaceiOSAPIDAO extends EgovComAbstractDAO {
      * @param vo
      *            - 탈퇴할 정보가 담긴 InterfaceiOSAPIVO
      * @return 회원탈퇴 결과
-     * @exception Exception
      */
-    public int deleteInterfaceInfo(InterfaceiOSAPIVO vo) throws Exception {
+    public int deleteInterfaceInfo(InterfaceiOSAPIVO vo) {
         return delete("interfaceiOSAPIDAO.deleteInterfaceInfo", vo);
     }
 

--- a/web-guide/src/main/java/egovframework/hyb/ios/mda/service/impl/MediaiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/mda/service/impl/MediaiOSAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @ ---------		---------	-------------------------------
  * @ 2012. 7. 30.		이율경		최초생성
  * @ 2012. 8. 14.		이해성       커스터마이징
+ * @ 2026. 6. 26.       이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 팀
  * @since 2012. 7. 30.
@@ -46,9 +47,8 @@ public class MediaiOSAPIDAO extends EgovComAbstractDAO {
 	 * 녹음 Media를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 CameraAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertMediaInfo(MediaiOSAPIFileVO vo) throws Exception {
+    public int insertMediaInfo(MediaiOSAPIFileVO vo) {
     	return (Integer)insert("mediaiOSAPIDAO.insertMediaInfo", vo);
     }
     
@@ -56,9 +56,8 @@ public class MediaiOSAPIDAO extends EgovComAbstractDAO {
 	 * 녹음 파일을 등록한다.
 	 * @param vo - 등록할 파일 정보가 담긴 CameraiOSAPIFileVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertMediaRecordFile(MediaiOSAPIFileVO vo) throws Exception {
+    public int insertMediaRecordFile(MediaiOSAPIFileVO vo) {
     	return (Integer)insert("mediaiOSAPIDAO.insertMediaRecordFile", vo);
     }
     
@@ -66,9 +65,8 @@ public class MediaiOSAPIDAO extends EgovComAbstractDAO {
 	 * 녹음 재생횟수를 수정한다.
 	 * @param vo - 등록할 정보가 담긴 MediaiOSAPIFileVO
 	 * @return 수정 결과
-	 * @exception Exception
 	 */
-    public int updateMediaInfoRevivCo(MediaiOSAPIVO vo) throws Exception {
+    public int updateMediaInfoRevivCo(MediaiOSAPIVO vo) {
     	return (Integer)update("mediaiOSAPIDAO.updateMediaInfoRevivCo", vo);
     }
     
@@ -76,9 +74,8 @@ public class MediaiOSAPIDAO extends EgovComAbstractDAO {
 	 * 미디어 정보를 조회한다.
 	 * @param VO - 조회할 정보가 담긴 MediaiOSAPIVO
 	 * @return 조회 목록
-	 * @exception Exception
 	 */
-	public MediaiOSAPIFileVO selectMediaInfoDetail(MediaiOSAPIVO vo) throws Exception {
+	public MediaiOSAPIFileVO selectMediaInfoDetail(MediaiOSAPIVO vo) {
 		return (MediaiOSAPIFileVO) selectOne("mediaiOSAPIDAO.selectMediaInfoDetail", vo);
 	}
 	
@@ -86,9 +83,8 @@ public class MediaiOSAPIDAO extends EgovComAbstractDAO {
 	 * 미디어 목록을 조회한다.
 	 * @param VO - 조회할 정보가 담긴 MediaiOSAPIDefaultVO
 	 * @return 조회 목록
-	 * @exception Exception
 	 */
-	public List<?> selectMediaInfoList(MediaiOSAPIVO searchVO) throws Exception {
+	public List<?> selectMediaInfoList(MediaiOSAPIVO searchVO) {
 		return selectList("mediaiOSAPIDAO.selectMediaInfoList", searchVO);
 	}
 	
@@ -96,9 +92,8 @@ public class MediaiOSAPIDAO extends EgovComAbstractDAO {
 	 * 미디어 파일 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 MediaiOSAPIFileVO
 	 * @return 이미지 파일 정보
-	 * @exception Exception
 	 */
-    public MediaiOSAPIFileVO selectMediaFileInfo(MediaiOSAPIFileVO vo) throws Exception {
+    public MediaiOSAPIFileVO selectMediaFileInfo(MediaiOSAPIFileVO vo) {
         return (MediaiOSAPIFileVO) selectOne("mediaiOSAPIDAO.selectMediaFileInfo", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/ios/nwk/service/impl/NetworkiOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/nwk/service/impl/NetworkiOSAPIDAO.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Repository;
  * @ ---------   ---------   -------------------------------
  * @ 2012.05.14   서준식                 최초생성
  * @ 2012.08.01    이해성        DeviceAPIGuide Network Info
+ *   2026.06.26   이백행                 [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 05. 14
@@ -49,9 +50,8 @@ public class NetworkiOSAPIDAO extends EgovComAbstractDAO {
 	 * 네트워크 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 NetworkAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertNetworkInfo(NetworkiOSAPIVO vo) throws Exception {
+    public int insertNetworkInfo(NetworkiOSAPIVO vo) {
         return (Integer)insert("networkiOSAPIDAO.insertNetworkInfo", vo);
     }
 
@@ -59,9 +59,8 @@ public class NetworkiOSAPIDAO extends EgovComAbstractDAO {
 	 * 네트워크 정보를 수정한다.
 	 * @param vo - 수정할 정보가 담긴 NetworkAPIVO
 	 * @return void형
-	 * @exception Exception
 	 */
-    public int updateNetworkInfo(NetworkiOSAPIVO vo) throws Exception {
+    public int updateNetworkInfo(NetworkiOSAPIVO vo) {
     	return (Integer)update("networkiOSAPIDAO.updateNetworkInfo", vo);
     }
 
@@ -69,9 +68,8 @@ public class NetworkiOSAPIDAO extends EgovComAbstractDAO {
 	 * 네트워크 정보를 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 NetworkAPIVO
 	 * @return void형 
-	 * @exception Exception
 	 */
-    public int deleteNetworkInfo(NetworkiOSAPIVO vo) throws Exception {
+    public int deleteNetworkInfo(NetworkiOSAPIVO vo) {
     	return (Integer)delete("networkiOSAPIDAO.deleteNetworkInfo", vo);
     }
 
@@ -79,9 +77,8 @@ public class NetworkiOSAPIDAO extends EgovComAbstractDAO {
 	 * 네트워크 정보를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 NetworkAPIVO
 	 * @return 조회한 네트워크 정보
-	 * @exception Exception
 	 */
-    public NetworkiOSAPIVO selectNetworkInfo(NetworkiOSAPIVO vo) throws Exception {
+    public NetworkiOSAPIVO selectNetworkInfo(NetworkiOSAPIVO vo) {
         return (NetworkiOSAPIVO) selectOne("networkiOSAPIDAO.selectNetworkInfo", vo);
     }
 
@@ -89,9 +86,8 @@ public class NetworkiOSAPIDAO extends EgovComAbstractDAO {
 	 * 네트워크 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 NetworkAPIDefaultVO
 	 * @return 네트워크 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectNetworkInfoList(NetworkiOSAPIVO vo) throws Exception {
+    public List<?> selectNetworkInfoList(NetworkiOSAPIVO vo) {
         return selectList("networkiOSAPIDAO.selectNetworkInfoList", vo);
     	//return null;
     }
@@ -100,7 +96,6 @@ public class NetworkiOSAPIDAO extends EgovComAbstractDAO {
 	 * 네트워크 정보 총 갯수를 조회한다.
 	 * @param  vo - 조회할 정보가 담긴 NetworkAPIDefaultVO
 	 * @return 네트워크 정보 총 갯수
-	 * @exception
 	 */
     public int selectNetworkInfoListTotCnt(NetworkiOSAPIVO vo) {
         return (Integer) selectOne("networkAPIDAO.selectNetworkInfoListTotCnt", vo);

--- a/web-guide/src/main/java/egovframework/hyb/ios/vbr/service/impl/VibratoriOSAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/ios/vbr/service/impl/VibratoriOSAPIDAO.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Repository;
  * @  수정일      수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2012.07.18   이해성                최초생성
+ *   2026.06.26   이백행                [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2012. 07. 18
@@ -48,9 +49,8 @@ public class VibratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 알람 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 VibratorAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertVibrator(VibratoriOSAPIVO vo) throws Exception {
+    public int insertVibrator(VibratoriOSAPIVO vo) {
         return (Integer)insert("vibratoriOSAPIDAO.insertVibrator", vo);
     }
 
@@ -58,9 +58,8 @@ public class VibratoriOSAPIDAO extends EgovComAbstractDAO {
 	 * 알람 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VibratorAPIDefaultVO
 	 * @return 네트워크 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectVibratorList(VibratoriOSAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectVibratorList(VibratoriOSAPIDefaultVO searchVO) {
         return selectList("vibratoriOSAPIDAO.selectVibratorList", searchVO);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/mbl/bar/service/impl/BarcodescannerDeviceAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/mbl/bar/service/impl/BarcodescannerDeviceAPIDAO.java
@@ -29,6 +29,7 @@ import egovframework.hyb.mbl.bar.service.BarcodescannerAPIVO;
  * @Modification Information
  * @ @ 수정일 수정자 수정내용 @ --------- --------- ------------------------------- @
  *   2016.07.26 신성학 최초생성
+ *   2026.06.26 이백행 [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 07. 26
@@ -47,9 +48,8 @@ public class BarcodescannerDeviceAPIDAO extends EgovComAbstractDAO {
 	 * @param vo
 	 *            - 등록할 정보가 담긴 BarcodescannerAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-	public int insertBarcodescannerDevcie(BarcodescannerAPIVO vo) throws Exception {
+	public int insertBarcodescannerDevcie(BarcodescannerAPIVO vo) {
 
 		return (Integer) insert("barcodescannerDeviceAPIDAO.insertBarcodescannerDevcie", vo);
 
@@ -61,9 +61,8 @@ public class BarcodescannerDeviceAPIDAO extends EgovComAbstractDAO {
 	 * @param vo
 	 *            - 등록할 정보가 담긴 BarcodescannerAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-	public List<?> selectBarcodescannerDevcieList(BarcodescannerAPIDefaultVO searchVO) throws Exception {
+	public List<?> selectBarcodescannerDevcieList(BarcodescannerAPIDefaultVO searchVO) {
 
 		return selectList("barcodescannerDeviceAPIDAO.selectBarcodescannerDevcieList", searchVO);
 	}

--- a/web-guide/src/main/java/egovframework/hyb/mbl/fop/service/impl/FileOpenerDeviceAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/mbl/fop/service/impl/FileOpenerDeviceAPIDAO.java
@@ -31,6 +31,7 @@ import egovframework.hyb.mbl.fop.service.FileOpenerDeviceAPIDefaultVO;
  * @  수정일      수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2016.07.11   장성호               최초생성
+ *   2026.06.26   이백행               [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 07. 11
@@ -47,9 +48,8 @@ public class FileOpenerDeviceAPIDAO extends EgovComAbstractDAO {
 	 * Push Device 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 PushDeviceAPIDefaultVO
 	 * @return Push Device 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectFileOpenerDocumentList(FileOpenerDeviceAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectFileOpenerDocumentList(FileOpenerDeviceAPIDefaultVO searchVO) {
         return selectList("fileOpenerDeviceAPIDAO.selectDocumentListInfo", searchVO);
     }
 

--- a/web-guide/src/main/java/egovframework/hyb/mbl/jai/service/impl/JailbreakDetectionDeviceAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/mbl/jai/service/impl/JailbreakDetectionDeviceAPIDAO.java
@@ -16,6 +16,7 @@ import egovframework.hyb.mbl.jai.service.JailbreakDetectionDeviceAPIVO;
  * @  수정일       수정자                  수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2016.07.26    신성학                최초 작성
+ *   2026.06.26    이백행                [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 07. 26
@@ -32,9 +33,8 @@ public class JailbreakDetectionDeviceAPIDAO extends EgovComAbstractDAO{
 	 * JailbreakDetectionDevice 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 JailbreakDetectionAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertJailbreakDetectionDevcie(JailbreakDetectionDeviceAPIVO vo) throws Exception {
+    public int insertJailbreakDetectionDevcie(JailbreakDetectionDeviceAPIVO vo) {
     	
         return (Integer)insert("jailbreakDetectionDeviceAPIDAO.insertJailbreakDetectionDevcie", vo);
         
@@ -46,9 +46,8 @@ public class JailbreakDetectionDeviceAPIDAO extends EgovComAbstractDAO{
 	 * JailbreakDetectionDevice 정보를 조회한다.
 	 * @param vo - 등록할 정보가 담긴 JailbreakDetectionAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-	public List<?> selectJailbreakDetectionDevcieList(JailbreakDetectionDeviceAPIDefaultVO searchVO) throws Exception{
+	public List<?> selectJailbreakDetectionDevcieList(JailbreakDetectionDeviceAPIDefaultVO searchVO) {
 
 		return selectList("jailbreakDetectionDeviceAPIDAO.selectJailbreakDetectionDevcieList", searchVO);
 	}

--- a/web-guide/src/main/java/egovframework/hyb/mbl/pus/service/impl/PushDeviceAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/mbl/pus/service/impl/PushDeviceAPIDAO.java
@@ -32,6 +32,7 @@ import egovframework.hyb.mbl.pus.service.PushDeviceAPIVO;
  * @  수정일      수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2016.06.20   신성학               최초생성
+ *   2026.06.26   이백행               [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 06. 20
@@ -48,9 +49,8 @@ public class PushDeviceAPIDAO extends EgovComAbstractDAO {
 	 * Push Device 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 PushDeviceAPIDefaultVO
 	 * @return Push Device 정보 목록
-	 * @exception Exception
 	 */
-    public List<?> selectPushDeviceList(PushDeviceAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectPushDeviceList(PushDeviceAPIDefaultVO searchVO) {
         return selectList("pushDeviceAPIDAO.selectPushDeviceList", searchVO);
     }
 
@@ -58,9 +58,8 @@ public class PushDeviceAPIDAO extends EgovComAbstractDAO {
 	 * Push Device 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 PushDeviceAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertPushDevice(PushDeviceAPIVO vo) throws Exception {
+    public int insertPushDevice(PushDeviceAPIVO vo) {
         return (Integer)insert("pushDeviceAPIDAO.insertPushDevice", vo);
     }
 
@@ -68,18 +67,16 @@ public class PushDeviceAPIDAO extends EgovComAbstractDAO {
 	 * Push Notification 정보를 등록한다.
 	 * @param vo - 등록할 정보가 담긴 PushDeviceAPIVO
 	 * @return 등록 결과
-	 * @exception Exception
 	 */
-    public int insertPushInfo(PushDeviceAPIVO vo) throws Exception {
+    public int insertPushInfo(PushDeviceAPIVO vo) {
         return (Integer)insert("pushDeviceAPIDAO.insertVibratorInfo", vo);
     }
 	/**
 	 * Push Notification 기기 상세 조회를 한다.
 	 * @param vo - 등록할 정보가 담긴 PushDeviceAPIVO
 	 * @return 조회 결과
-	 * @exception Exception
 	 */
-    public PushDeviceAPIVO selectPushDevice(PushDeviceAPIVO vo) throws Exception {
+    public PushDeviceAPIVO selectPushDevice(PushDeviceAPIVO vo) {
         return (PushDeviceAPIVO) selectOne("pushDeviceAPIDAO.selectPushDevice", vo);
     }
 
@@ -87,9 +84,8 @@ public class PushDeviceAPIDAO extends EgovComAbstractDAO {
 	 * Push Notification 송신 메세지 조회를 한다.
 	 * @param vo - 등록할 정보가 담긴 PushDeviceAPIVO
 	 * @return 조회 결과
-	 * @exception Exception
 	 */
-    public List<?> selectPushMessageList(PushDeviceAPIVO vo) throws Exception {
+    public List<?> selectPushMessageList(PushDeviceAPIVO vo) {
         return selectList("pushDeviceAPIDAO.selectPushMessageList", vo);
     }
 
@@ -97,9 +93,8 @@ public class PushDeviceAPIDAO extends EgovComAbstractDAO {
      * Push Notification 등록된 기기가 있는지 조회를 한다.
      * @param vo
      * @return
-     * @throws Exception
      */
-    public int selectPushDeviceCount(PushDeviceAPIVO vo) throws Exception {
+    public int selectPushDeviceCount(PushDeviceAPIVO vo) {
     	return (Integer)selectOne("pushDeviceAPIDAO.selectPushDeviceCount", vo);
     }
 

--- a/web-guide/src/main/java/egovframework/hyb/mbl/stm/service/impl/StreamingMediaAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/mbl/stm/service/impl/StreamingMediaAPIDAO.java
@@ -17,6 +17,7 @@ import egovframework.hyb.mbl.stm.service.StreamingMediaAPIVO;
  * @  수정일            수정자        수정내용
  * @ ---------        ---------    -------------------------------
  * @ 2016. 7. 14.     장성호        최초생성
+ * @ 2026. 6. 26.     이백행        [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 팀
  * @since 2016. 7. 14.
@@ -31,9 +32,8 @@ public class StreamingMediaAPIDAO extends EgovComAbstractDAO {
      * 미디어 목록을 조회한다.
      * @param VO - 조회할 정보가 담긴 StreamingMediaAPIVO
      * @return 조회 목록
-     * @exception Exception
      */
-    public List<?> selectMediaInfoList(StreamingMediaAPIDefaultVO searchVO) throws Exception {
+    public List<?> selectMediaInfoList(StreamingMediaAPIDefaultVO searchVO) {
         return selectList("streamingMediaAPIDAO.selectMediaInfoList", searchVO);
     }
     
@@ -41,14 +41,13 @@ public class StreamingMediaAPIDAO extends EgovComAbstractDAO {
      * 미디어 파일 정보를 조회한다.
      * @param vo - 조회할 정보가 담긴 StreamingMediaAPIVO
      * @return 이미지 파일 정보
-     * @exception Exception
      */
-    public StreamingMediaAPIFileVO selectMediaFileInfo(StreamingMediaAPIFileVO vo) throws Exception {
+    public StreamingMediaAPIFileVO selectMediaFileInfo(StreamingMediaAPIFileVO vo) {
         return (StreamingMediaAPIFileVO) selectOne("streamingMediaAPIDAO.selectMediaFileInfo", vo);
     }
     
     
-    public int updateMediaInfoRevivCo(StreamingMediaAPIVO vo) throws Exception {
+    public int updateMediaInfoRevivCo(StreamingMediaAPIVO vo) {
         return (Integer)update("streamingMediaAPIDAO.updateMediaInfoRevivCo", vo);
     }
 }

--- a/web-guide/src/main/java/egovframework/hyb/mbl/upd/service/impl/ResourceUpdateDeviceAPIDAO.java
+++ b/web-guide/src/main/java/egovframework/hyb/mbl/upd/service/impl/ResourceUpdateDeviceAPIDAO.java
@@ -29,6 +29,7 @@ import egovframework.hyb.mbl.upd.service.ResourceUpdateDeviceAPIVO;
  * @  수정일      수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2016.06.20   신용호               최초생성
+ *   2026.06.26   이백행               [2026년 컨트리뷰션] 불필요한 예외(throws Exception) 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 06. 20
@@ -45,9 +46,8 @@ public class ResourceUpdateDeviceAPIDAO extends EgovComAbstractDAO {
 	 * Push Device 정보 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 PushDeviceAPIDefaultVO
 	 * @return Push Device 정보 목록
-	 * @exception Exception
 	 */
-    public ResourceUpdateDeviceAPIVO selectResourceUpdateVersionInfo(ResourceUpdateDeviceAPIVO searchVO) throws Exception {
+    public ResourceUpdateDeviceAPIVO selectResourceUpdateVersionInfo(ResourceUpdateDeviceAPIVO searchVO) {
         return (ResourceUpdateDeviceAPIVO) selectOne("resourceUpdateDeviceAPIDAO.selectResourceUpdateVersionInfo", searchVO);
     }
 


### PR DESCRIPTION
### 변경 이유
- 실제 예외를 발생시키지 않음에도 선언되어 있던 `throws Exception` 구문이 코드를 읽는 데 오해를 불러일으킬 수 있어 제거합니다.

### 작업 내용
- 불필요한 `throws Exception` 선언 삭제
- 기능 변경 없는 코드 개선

https://youtu.be/n-Hm1XQxiqI
